### PR TITLE
Fixed tab order

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,19 +1,19 @@
 import css from "rollup-plugin-import-css";
-import typescript from 'rollup-plugin-typescript2';
+import typescript from "rollup-plugin-typescript2";
 
-import pkg from './package.json'
+import pkg from "./package.json";
 
 export default {
-  input: 'src/index.ts',
-  output: [
-    {
-      file: pkg.main,
-      format: 'cjs',
-      exports: 'named',
-      sourcemap: true,
-      strict: false
-    }
-  ],
-  plugins: [css({ output: "react-duration-control" }), typescript()],
-  external: ['react', 'react-dom']
-}
+	input: "src/index.ts",
+	output: [
+		{
+			file: pkg.main,
+			format: "cjs",
+			exports: "named",
+			sourcemap: true,
+			strict: false
+		}
+	],
+	plugins: [css({ output: "react-duration-control.css" }), typescript()],
+	external: ["react", "react-dom"]
+};

--- a/src/DurationControl.css
+++ b/src/DurationControl.css
@@ -63,10 +63,12 @@
   outline-width: 0;
 }
 
-.react-duration-control-unit-text {
+.duration-control-unit-input.unfocused {
   cursor: pointer;
   font-weight: bolder;
   border: none;
+  font-size: 1em;
+  padding: 0;
 }
 
 .react-duration-control-inline-text {

--- a/src/DurationControl.css
+++ b/src/DurationControl.css
@@ -1,105 +1,106 @@
 .react-duration-control {
-    display: inline-block;
-    font-family: Arial, sans-serif;
-    border-radius: 3px;
-    background-color: rgb(255, 255, 255);
+  display: inline-block;
+  font-family: Arial, sans-serif;
+  border-radius: 3px;
+  background-color: rgb(255, 255, 255);
 }
 
 .react-duration-control.disabled {
-    background-color: rgb(240, 240, 240);
+  background-color: rgb(240, 240, 240);
 }
 
 .react-duration-control-fieldset {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-    box-sizing: content-box;
-    height: fit-content;
-    padding: 5px;
-    border: 1px rgb(0, 0, 0, 0.4) solid;
-    border-radius: 3px;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  box-sizing: content-box;
+  height: fit-content;
+  padding: 5px;
+  border: 1px rgb(0, 0, 0, 0.4) solid;
+  border-radius: 3px;
 }
 
 .react-duration-control.focused > .react-duration-control-fieldset {
-    padding: 4px;
-    border: 2px rgba(0, 160, 255) solid;
+  padding: 4px;
+  border: 2px rgba(0, 160, 255) solid;
 }
 
 .react-duration-control.focused > .react-duration-control-fieldset > .react-duration-control-label {
-    margin-bottom: -5px;
-    color: rgba(0, 160, 255);
+  margin-bottom: -5px;
+  color: rgba(0, 160, 255);
 }
 
 .react-duration-control.disabled > .react-duration-control-fieldset {
-    border: 1px rgb(0, 0, 0, 0.2) solid;
+  border: 1px rgb(0, 0, 0, 0.2) solid;
 }
 
 .react-duration-control-label {
-    font-size: 0.8em;
-    margin-bottom: -6px;
-    padding: 0px 5px;
-    color: rgb(0, 0, 0, 0.5);
+  font-size: 0.8em;
+  margin-bottom: -6px;
+  padding: 0px 5px;
+  color: rgb(0, 0, 0, 0.5);
 }
 
 .react-duration-control-elements-container {
-    display: flex;
-    flex-direction: row;
-    min-height: 21px;
-    padding: 4px 8px;
-    overflow: hidden;
+  display: flex;
+  flex-direction: row;
+  min-height: 21px;
+  padding: 4px 8px;
+  overflow: hidden;
 }
 
-.react-duration-control.disabled > .react-duration-control-fieldset > .react-duration-control-elements-container {
-    opacity: 0.7;
+.react-duration-control.disabled
+  > .react-duration-control-fieldset
+  > .react-duration-control-elements-container {
+  opacity: 0.7;
 }
 
 .duration-control-unit-input-wrapper {
-    display: flex;
+  display: flex;
 }
 
 .duration-control-unit-input:focus {
-    outline-width: 0;
+  outline-width: 0;
 }
 
 .react-duration-control-unit-text {
-    display: inline-flex;
-    align-items: center;
-    cursor: pointer;
-    font-weight: bolder;
+  cursor: pointer;
+  font-weight: bolder;
+  border: none;
 }
 
 .react-duration-control-inline-text {
-    display: inline-flex;
-    align-items: center;
-    white-space: pre;
+  display: inline-flex;
+  align-items: center;
+  white-space: pre;
 }
 
 .spinner-button-container {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    width: 20px;
-    margin-inline-start: 6px;
-    margin-inline-end: 2px;
-    border-radius: 3px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  width: 20px;
+  margin-inline-start: 6px;
+  margin-inline-end: 2px;
+  border-radius: 3px;
 }
 
 .spinner-button-container > .spinner-button {
-    flex-grow: 1;
-    cursor: pointer;
-    padding: 0px;
-    line-height: 50%;
-    margin: 0;
-    border: 1px rgb(160, 160, 160) solid;
+  flex-grow: 1;
+  cursor: pointer;
+  padding: 0px;
+  line-height: 50%;
+  margin: 0;
+  border: 1px rgb(160, 160, 160) solid;
 }
 
 .spinner-button-container > .spinner-button-up {
-    border-top-left-radius: 3px;
-    border-top-right-radius: 3px;
+  border-top-left-radius: 3px;
+  border-top-right-radius: 3px;
 }
 
 .spinner-button-container > .spinner-button-down {
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
-    border-top: none;
+  border-bottom-left-radius: 3px;
+  border-bottom-right-radius: 3px;
+  border-top: none;
 }

--- a/src/DurationControlUnitInput.tsx
+++ b/src/DurationControlUnitInput.tsx
@@ -65,24 +65,6 @@ export const DurationControlUnitInput: React.FunctionComponent<DurationControlUn
 		return focused ? value : String(value).padStart(characterLength, "0");
 	};
 
-	// If the unit does not currently have focus then we display the unit value as a span and not an input.
-	if (!focused || disabled) {
-		return (
-			<span
-				tabIndex={0}
-				className="react-duration-control-unit-text"
-				onFocus={() => {
-					if (!disabled) {
-						setFocused(true);
-						onFocus();
-					}
-				}}
-			>
-				{getValue()}
-			</span>
-		);
-	}
-
 	return (
 		<div className={`duration-control-unit-input-wrapper ${type}`}>
 			<input
@@ -100,6 +82,12 @@ export const DurationControlUnitInput: React.FunctionComponent<DurationControlUn
 					// Only call our 'onChange' callback if our value is actually a valid number.
 					if (!Number.isNaN(Number(event.target.value))) {
 						onChange(parseInt(event.target.value, 10));
+					}
+				}}
+				onFocus={() => {
+					if (!disabled) {
+						setFocused(true);
+						onFocus();
 					}
 				}}
 				onBlur={(event) => {
@@ -135,7 +123,9 @@ export const DurationControlUnitInput: React.FunctionComponent<DurationControlUn
 						onDownArrowKeyPress();
 					}
 				}}
-				className={`duration-control-unit-input ${type}`}
+				className={`duration-control-unit-input ${type} ${
+					focused ? "" : "react-duration-control-unit-text"
+				}`}
 				maxLength={characterLength}
 				style={{ width: `${characterLength}ch` }}
 			></input>

--- a/src/DurationControlUnitInput.tsx
+++ b/src/DurationControlUnitInput.tsx
@@ -70,7 +70,6 @@ export const DurationControlUnitInput: React.FunctionComponent<DurationControlUn
 			<input
 				ref={inputRef}
 				type="text"
-				autoFocus
 				value={getValue()}
 				onChange={(event) => {
 					// If our input is empty then the input value should be null.

--- a/src/DurationControlUnitInput.tsx
+++ b/src/DurationControlUnitInput.tsx
@@ -123,9 +123,7 @@ export const DurationControlUnitInput: React.FunctionComponent<DurationControlUn
 						onDownArrowKeyPress();
 					}
 				}}
-				className={`duration-control-unit-input ${type} ${
-					focused ? "" : "react-duration-control-unit-text"
-				}`}
+				className={`duration-control-unit-input ${type} ${focused ? "" : "unfocused"}`}
 				maxLength={characterLength}
 				style={{ width: `${characterLength}ch` }}
 			></input>

--- a/stories/DurationControl.stories.tsx
+++ b/stories/DurationControl.stories.tsx
@@ -42,7 +42,7 @@ const Template: ComponentStory<typeof DurationControlWrapper> = (args) => (
 
 export const AllUnits = Template.bind({});
 AllUnits.args = {
-	pattern: "Days {dd} Hours {hh} Minutes {mm} Seconds {ss} Millis {fff}",
+	pattern: "Days {dd} Hours {hh} Minutes {mm} Seconds {ss} Millis {ff}",
 	disabled: false,
 	hideSpinner: false,
 	label: ""


### PR DESCRIPTION
Hi Nik 🙂,

Here the fixes performed:

1. Fixed rollup.config.js
2. Fixed input css to display as text when input does not have focus,
3. Removed unit spans and display only unit inputs.
