### PR TITLE
Allow numbers above 99

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,4 @@ The backing value for the control is the number of milliseconds represented by t
 | label | string | | The control label content. |
 | disabled | bool | `false` | If `true`, the control will be disabled. |
 | hideSpinner | bool | `false` | If `true`, the up and down spinner buttons will not be shown. |
+| isRolloverUnitValues | bool    | `false` | If `true`, it allows unit values (e.g., minutes, hours) to roll over to the next higher unit. For example: <br/> - Typing 59 into the minutes field and incrementing by 1 will reset the minutes to 0 and increment the hours by 1. <br/> - Typing 65 into the minutes field will reset the minutes to 5 and increment the hours by 1. |

--- a/src/DurationControl.tsx
+++ b/src/DurationControl.tsx
@@ -77,6 +77,14 @@ export type DurationControlProps = {
 
 	/** The amount to increment/decrement the millisecond unit value by when an up/down arrow key or spinner button is pressed. Defaults to 1. */
 	fStep?: number;
+
+	/**
+	 * If enable, it allows unit values (e.g., minutes, hours) to roll over to the next higher unit.
+	 * For example:
+	 * - Typing 59 into the minutes field and incrementing by 1 will reset the minutes to 0 and increment the hours by 1.
+	 * - Typing 65 into the minutes field will reset the minutes to 5 and increment the hours by 1.
+	 */
+	isRolloverUnitValues?: boolean;
 };
 
 /**
@@ -294,11 +302,20 @@ export class DurationControl extends React.Component<DurationControlProps, Durat
 
 		// Work out the difference between the new and previous unit values in millis.
 		const unitValueMillisDifference = newUnitValueMillis - previousUnitValueMillis;
-
 		const updatedMilliseconds = this.state.milliseconds + unitValueMillisDifference;
 
-		// Update the unit value.
-		unitElement.value = clampedValue;
+		if (this.props.isRolloverUnitValues) {
+			// Reset values and let spreadMillisAcrossUnitElements sort them out
+			elements
+				.filter((element) => typeof element !== "string")
+				.forEach((element: DurationControlUnit) => {
+					element.value = 0;
+				});
+			DurationControl._spreadMillisAcrossUnitElements(updatedMilliseconds, elements);
+		} else {
+			// Update the unit value.
+			unitElement.value = clampedValue;
+		}
 
 		this.setState({ elements, milliseconds: updatedMilliseconds });
 

--- a/src/DurationControl.tsx
+++ b/src/DurationControl.tsx
@@ -485,13 +485,14 @@ export class DurationControl extends React.Component<DurationControlProps, Durat
 	 * @returns An array of duration control elements, either strings or unit input definitions.
 	 */
 	private static _parseElementsFromProps(props: DurationControlProps): DurationControlElement[] {
-		const patternRegex = /(\{[dhmsf]+\*?\})/g;
 		const asteriskRegex = /\*/;
-		const dayUnitRegex = /^\{d+\*?\}$/g;
-		const hourUnitRegex = /^\{h+\*?\}$/g;
-		const minuteUnitRegex = /^\{m+\*?\}$/g;
-		const secondUnitRegex = /^\{s+\*?\}$/g;
-		const millisecondUnitRegex = /^\{f+\*?\}$/g;
+		const patternRegex =
+			/(\{d+\}|\{h+\}|\{m+\}|\{s+\}|\{f+\}|\{d\*\}|\{h\*\}|\{m\*\}|\{s\*\}|\{f\*\})/g;
+		const dayUnitRegex = /^{d+}$|^{d\*\}$/g;
+		const hourUnitRegex = /^{h+}$|^{h\*\}$/g;
+		const minuteUnitRegex = /^{m+}$|^{m\*\}$/g;
+		const secondUnitRegex = /^{s+}$|^{s\*\}$/g;
+		const millisecondUnitRegex = /^{f+}$|^{f\*\}$/g;
 
 		const getMaxAndStepValue = (unitType: DurationUnitType, characters: number | undefined) => {
 			// Get the max and step value for this unit type.
@@ -500,7 +501,7 @@ export class DurationControl extends React.Component<DurationControlProps, Durat
 			// If pattern has an asterisk, characters are undefined so any numbers of digits are allowed so the unit max will be the explicitly defined unit max, if no defined it defaults to the JS safe integer.
 			// If pattern has no an asterisk, characters are defined, the unit max will be the smallest between the explicitly defined unit max and the max value allowed for the character count.
 			return {
-				max: characters == undefined ? max : Math.min(Math.pow(10, characters) - 1, max),
+				max: characters === undefined ? max : Math.min(Math.pow(10, characters) - 1, max),
 				step
 			};
 		};
@@ -512,10 +513,9 @@ export class DurationControl extends React.Component<DurationControlProps, Durat
 					return previous;
 				}
 
-				// If pattern has an asterisk, any numbers of digits are allowed
-				const isAnyMaxNumberAllowed = asteriskRegex.test(current);
 				// Get the number of characters for the unit.
-				const characters = isAnyMaxNumberAllowed ? undefined : current.length - 2;
+				// If pattern has an asterisk, any numbers of digits are allowed.
+				const characters = asteriskRegex.test(current) ? undefined : current.length - 2;
 
 				if (current.match(dayUnitRegex)) {
 					return [

--- a/src/DurationControlUnitInput.tsx
+++ b/src/DurationControlUnitInput.tsx
@@ -13,7 +13,7 @@ export type DurationControlUnitInputProps = {
 	type: DurationUnitType;
 
 	/** The character length of the unit input. */
-	characterLength: number;
+	characterLength: number | undefined;
 
 	/** The unit value. */
 	value: number | null;
@@ -53,6 +53,13 @@ export const DurationControlUnitInput: React.FunctionComponent<DurationControlUn
 }) => {
 	const inputRef = React.useRef<HTMLInputElement>(null);
 	const [focused, setFocused] = React.useState(false);
+	const [width, setWidth] = React.useState<number | undefined>(1);
+
+	React.useEffect(() => {
+		value !== null && characterLength == undefined
+			? setWidth(value.toString().length)
+			: setWidth(characterLength);
+	}, [value, characterLength]);
 
 	// A helper function to get the raw value if the unit has focus or our value padded with zeros if it doesn't.
 	const getValue = (): string | number => {
@@ -62,7 +69,12 @@ export const DurationControlUnitInput: React.FunctionComponent<DurationControlUn
 		}
 
 		// If our field is focused then we want to show the raw value. If it isn't then we want our padded value.
-		return focused ? value : String(value).padStart(characterLength, "0");
+		return focused
+			? value
+			: String(value).padStart(
+					characterLength == undefined ? value.toString.length : characterLength,
+					"0"
+			  );
 	};
 
 	return (
@@ -124,7 +136,7 @@ export const DurationControlUnitInput: React.FunctionComponent<DurationControlUn
 				}}
 				className={`duration-control-unit-input ${type} ${focused ? "" : "unfocused"}`}
 				maxLength={characterLength}
-				style={{ width: `${characterLength}ch` }}
+				style={{ width: `${width ? width : 1}ch` }}
 			></input>
 		</div>
 	);

--- a/src/DurationControlUnitInput.tsx
+++ b/src/DurationControlUnitInput.tsx
@@ -53,13 +53,6 @@ export const DurationControlUnitInput: React.FunctionComponent<DurationControlUn
 }) => {
 	const inputRef = React.useRef<HTMLInputElement>(null);
 	const [focused, setFocused] = React.useState(false);
-	const [width, setWidth] = React.useState<number | undefined>(1);
-
-	React.useEffect(() => {
-		value !== null && characterLength == undefined
-			? setWidth(value.toString().length)
-			: setWidth(characterLength);
-	}, [value, characterLength]);
 
 	// A helper function to get the raw value if the unit has focus or our value padded with zeros if it doesn't.
 	const getValue = (): string | number => {
@@ -69,12 +62,9 @@ export const DurationControlUnitInput: React.FunctionComponent<DurationControlUn
 		}
 
 		// If our field is focused then we want to show the raw value. If it isn't then we want our padded value.
-		return focused
+		return focused || characterLength === undefined
 			? value
-			: String(value).padStart(
-					characterLength == undefined ? value.toString.length : characterLength,
-					"0"
-			  );
+			: String(value).padStart(characterLength, "0");
 	};
 
 	return (
@@ -136,7 +126,11 @@ export const DurationControlUnitInput: React.FunctionComponent<DurationControlUn
 				}}
 				className={`duration-control-unit-input ${type} ${focused ? "" : "unfocused"}`}
 				maxLength={characterLength}
-				style={{ width: `${width ? width : 1}ch` }}
+				style={{
+					width: `${
+						characterLength !== undefined ? characterLength : value?.toString().length ?? 1
+					}ch`
+				}}
 			></input>
 		</div>
 	);

--- a/stories/DurationControl.stories.tsx
+++ b/stories/DurationControl.stories.tsx
@@ -3,7 +3,13 @@ import { ComponentStory, ComponentMeta } from "@storybook/react";
 
 import { DurationControl } from "../src/DurationControl";
 
-const DurationControlWrapper = ({ pattern, disabled, hideSpinner, label }) => {
+const DurationControlWrapper = ({
+	pattern,
+	disabled,
+	hideSpinner,
+	label,
+	isRolloverUnitValues
+}) => {
 	const [millis, setMillis] = useState(0);
 
 	return (
@@ -17,6 +23,7 @@ const DurationControlWrapper = ({ pattern, disabled, hideSpinner, label }) => {
 				onChange={(value) => setMillis(value)}
 				onUnitFocus={(unit) => console.log("Focus", unit)}
 				onUnitBlur={(unit) => console.log("Blur", unit)}
+				isRolloverUnitValues={isRolloverUnitValues}
 			/>
 			<h3>Millis</h3>
 			<input
@@ -45,5 +52,6 @@ AllUnits.args = {
 	pattern: "Days {dd} Hours {hh} Minutes {mm} Seconds {ss} Millis {ff}",
 	disabled: false,
 	hideSpinner: false,
-	label: ""
+	label: "",
+	isRolloverUnitValues: false
 };


### PR DESCRIPTION
Expanded regex expressions to include any number of digits such as:
	pattern: "Days {d*} Hours {h*} Minutes {m*} Seconds {s*} Millis {f*}",
	pattern: "{d*} Days {h*} Hours {m*} Minutes {s*} Seconds {f*} Millis",